### PR TITLE
Remove version attribute from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name": "npr/npr-one-backend-proxy",
     "description": "A server-side proxy for interacting with the NPR One API's authorization server",
-    "version": "2.0.0",
     "keywords": [
         "npr",
         "oauth",


### PR DESCRIPTION
Hey @xiehan and @kristen-kagei,
I was looking into making a change to this library and realized that there is currently a mismatch between the tags in this repo and what versions are being scraped by Packagist. Packagist doesn’t have any of the 3.x releases that are tagged in this repo. The problem seems to be that the version in `composer.json` wasn’t updated for any of the 3.x changes. In [this post](https://medium.com/packagist/tagged-a-new-release-for-composer-and-it-wont-show-up-on-packagist-org-or-on-private-packagist-efaf21c212ff) they recommend removing the version attribute from `composer.json` completely, and let Packagist infer the version from the git tag instead. They also recommend not replacing any existing git tags when fixing issues such as this. Therefore, I suggest we merge this PR into master and then tag master as v3.1.1.
 